### PR TITLE
lichess: Add support for games ended by Cheat Detection

### DIFF
--- a/src/formatters/lichess.ts
+++ b/src/formatters/lichess.ts
@@ -126,6 +126,12 @@ export function getResult(json: Partial<LichessGame>): Result {
                 via: 'variant',
                 label: getResultStringForColor(json.winner),
             }
+        case 'cheat':
+            return {
+                winner: json.winner,
+                via: 'cheat',
+                label: getResultStringForColor(json.winner),
+            }
         case 'draw':
             return {
                 outcome: 'draw',

--- a/src/types.ts
+++ b/src/types.ts
@@ -403,7 +403,7 @@ export interface Result {
         | 'timeout'
         | 'abandonment'
         | 'noStart' // Did not make a move
-        | 'cheat'  // Ended by cheat detection
+        | 'cheat' // Ended by cheat detection
         | '50moves'
         | 'variant' // For example, threecheck or bughousepartnerlose
     label: GameResultString

--- a/src/types.ts
+++ b/src/types.ts
@@ -403,6 +403,7 @@ export interface Result {
         | 'timeout'
         | 'abandonment'
         | 'noStart' // Did not make a move
+        | 'cheat'  // Ended by cheat detection
         | '50moves'
         | 'variant' // For example, threecheck or bughousepartnerlose
     label: GameResultString

--- a/tests/format-lichess.test.ts
+++ b/tests/format-lichess.test.ts
@@ -229,6 +229,33 @@ describe('results', () => {
     })
 })
 
+test('test game end by cheat detection (same position in analysis board)', () => {
+    // sample game from:
+    // curl -H 'Accept: application/json' 'https://lichess.org/game/export/qwbLhewv?evals=false'
+
+    let input: LichessGame = {
+        id: 'qwbLhewv',
+        rated: false,
+        variant: 'fromPosition',
+        speed: 'rapid',
+        perf: 'fromPosition',
+        createdAt: 1660763693169,
+        lastMoveAt: 1660764265251,
+        status: 'cheat',
+        players: {
+            white: { user: { name: 'rufusson_dufus', patron: true, id: 'rufusson_dufus' }, rating: 2417 },
+            black: { user: { name: 'Xiong_Jina', id: 'xiong_jina' }, rating: 2260 },
+        },
+        initialFen: 'r2q1rk1/pb3p1p/2p2np1/8/1p1bPPnN/6P1/PPQ1B2P/R1BN1R1K w - - 2 18',
+        winner: 'white',
+        moves: 'Bf3 Qb6 e5 Rae8 Ng2 Ba6 Re1 Bf2 Re2 Bxe2 Qxe2 h5 Qf1 Bd4 exf6',
+        clock: { initial: 600, increment: 5, totalTime: 800 },
+    }
+    let formattedGame = formatGame(input)
+
+    expect(formattedGame.result).toStrictEqual({ winner: 'white', via: 'cheat', label: '1-0' })
+})
+
 describe('test invalid result', () => {
     test.each<Partial<LichessGame>>([{ status: 'invalidresult' }])('test results', async (input) => {
         await expect(() => getResult(input)).toThrowError(/Unexpected result/)


### PR DESCRIPTION
When lichess detects a user visits a position after the first moves in the analysis board, they automatically abort the game with a _Cheat Detected_ messages.
Support this too instead of crashing.
